### PR TITLE
[Branch doc] implement more fluent api

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -30,6 +30,15 @@ unsigned int volkswagen_crc(uint32_t address, const std::vector<uint8_t> &d);
 unsigned int hkg_can_fd_checksum(uint32_t address, const std::vector<uint8_t> &d);
 unsigned int pedal_checksum(const std::vector<uint8_t> &d);
 
+
+struct CanData {
+  CanData(uint32_t address, uint16_t busTime, std::vector<uint8_t> dat, uint8_t src): address(address), busTime(busTime), dat(dat), src(src) {};
+  uint32_t address;
+  uint16_t busTime;
+  std::vector<uint8_t> dat;
+  uint8_t src;
+}; 
+
 class MessageState {
 public:
   uint32_t address;
@@ -75,6 +84,7 @@ public:
   #ifndef DYNAMIC_CAPNP
   void update_string(const std::string &data, bool sendcan);
   void UpdateCans(uint64_t sec, const capnp::List<cereal::CanData>::Reader& cans);
+  void update_candata(uint64_t sec, const std::vector<CanData> cans);
   #endif
   void UpdateCans(uint64_t sec, const capnp::DynamicStruct::Reader& cans);
   void UpdateValid(uint64_t sec);

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -72,11 +72,19 @@ cdef extern from "common_dbc.h":
 cdef extern from "common.h":
   cdef const DBC* dbc_lookup(const string);
 
+  cdef cppclass CanData:
+    CanData(uint32_t, uint16_t, vector[uint8_t], uint8_t)
+    uint32_t address;
+    uint16_t busTime;
+    vector[uint8_t] dat;
+    uint8_t src;
+
   cdef cppclass CANParser:
     bool can_valid
     bool bus_timeout
     CANParser(int, string, vector[MessageParseOptions], vector[SignalParseOptions])
     void update_string(string, bool)
+    void update_candata(int, vector[CanData])
     vector[SignalValue] query_latest()
 
   cdef cppclass CANPacker:

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -9,6 +9,7 @@ from libcpp cimport bool
 from libcpp.map cimport map
 
 from .common cimport CANParser as cpp_CANParser
+from .common cimport CanData as cpp_CanData
 from .common cimport SignalParseOptions, MessageParseOptions, dbc_lookup, SignalValue, DBC
 
 import os
@@ -138,6 +139,17 @@ cdef class CANParser:
       self.can.update_string(s, sendcan)
       updated_addrs.update(self.update_vl())
     return updated_addrs
+
+  def update_candata(self, sec, candata):
+    cdef:
+        vector[cpp_CanData] cpp_candata
+    for v in self.vl_all.values():
+      v.clear()
+
+    for data in candata:
+        cpp_candata.push_back(cpp_CanData(data.address, data.busTime, data.dat, data.src))
+    self.can.update_candata(sec, cpp_candata)
+    return self.update_vl()
 
 
 cdef class CANDefine():

--- a/generator/toyota/toyota_nodsu_pt.dbc
+++ b/generator/toyota/toyota_nodsu_pt.dbc
@@ -51,4 +51,4 @@ CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along
 CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
 
 VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
-VAL_ 610 LKA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 1 "standby";
+VAL_ 610 LKA_STATE 25 "temporary_fault" 17 "permanent_fault" 9 "temporary_fault2" 5 "active" 1 "standby";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -570,4 +570,4 @@ CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along
 CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
 
 VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
-VAL_ 610 LKA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 1 "standby";
+VAL_ 610 LKA_STATE 25 "temporary_fault" 17 "permanent_fault" 9 "temporary_fault2" 5 "active" 1 "standby";


### PR DESCRIPTION
This branch implements more fluent api to parse can data, especially from rlog and panda.

Usage: 

```python
from openpilot.opendbc.can.parser import CANParser

# CANParser initialization
signals = [
    # sig_name, sig_address
    ("WHEEL_SPEED_FL", "WHEEL_SPEEDS"),
    ("WHEEL_SPEED_FR", "WHEEL_SPEEDS"),
    ("WHEEL_SPEED_RL", "WHEEL_SPEEDS"),
    ("WHEEL_SPEED_RR", "WHEEL_SPEEDS"),
    ("STEER_TORQUE_DRIVER", "STEER_TORQUE_SENSOR"),
    ("STEER_TORQUE_EPS", "STEER_TORQUE_SENSOR"),
    ("STEER_ANGLE", "STEER_TORQUE_SENSOR"),
    ("STEER_ANGLE_INITIALIZING", "STEER_TORQUE_SENSOR"),
]
cp = CANParser("dbc_name", signals, enforce_checks=False, bus=0)

# type definition
from collections import namedtuple
CANData = namedtuple('CANData', ['address', 'busTime', 'dat', 'src'])

# usage
from panda import Panda    
import time    
p = Panda()

while True:
    result = p.can_recv()
    candata = [CANData(address, busTime, data, bus) for address, busTime, data, bus  in result]
    sec = time.time()
    cp.update_candata(sec, candata)
    print(cp.vl["WHEEL_SPEEDS"]["WHEEL_SPEED_FL"])
    sleep(0.001)
```

> **Note**
> Keep it in mind that you have to specify bus number when initialization. It means that can messages in different bus does not parsed. For example, in order to treat 'STEERING_LKA' values, you have to prepare `CANParser` whose bus number is 128.